### PR TITLE
Added option to stop at EOS token

### DIFF
--- a/ults/functional.py
+++ b/ults/functional.py
@@ -25,6 +25,7 @@ def generate(
     prior_empirical_llm_samples: torch.Tensor | None = None,
     sample_size: int = 1000,
     output_full_sequence: bool = False,
+    stop_at_eos: bool = True,
 ) -> ULTSOutput:
     """ULTS: Uncertainty-guided Likelihood-Tree Search.
 
@@ -41,6 +42,7 @@ def generate(
         sample_size: Number of posterior samples to use.
         output_full_sequence: Whether to output the full sequence (context + generated).
             The outputted loglik will reflect this.
+        stop_at_eos: Consider sequences that end with <EOS> as leaf nodes.
 
     Returns:
         ults_output: A dataclass containing `sequence`, `loglik`, and `n_llm_calls`.
@@ -56,6 +58,7 @@ def generate(
         prior_dirichlet_alpha=prior_dirichlet_alpha,
         prior_empirical_llm_samples=prior_empirical_llm_samples,
         sample_size=sample_size,
+        stop_at_eos=stop_at_eos,
     )
 
     # Generation results --- full sequence and total_loglik include context

--- a/ults/ults.py
+++ b/ults/ults.py
@@ -38,7 +38,7 @@ class ULTS:
         prior_dirichlet_alpha: float = 0.0001,
         prior_empirical_llm_samples: torch.Tensor | None = None,
         sample_size: int = 1000,
-        stop_at_eos: bool = False,
+        stop_at_eos: bool = True,
     ):
         if prior_kind == "empirical" and prior_empirical_llm_samples is None:
             raise ValueError(


### PR DESCRIPTION
Nodes for sequences that end with EOS can now also be considered leaf nodes.

Do we want this to be "true" or "false" per default?

Do we want only such nodes to be leaf nodes, or do we want to keep other nodes (those at maximum depth) as leaf nodes, too?
It's currently the latter. 